### PR TITLE
Omit social media URL from spec.author

### DIFF
--- a/Tablier.podspec
+++ b/Tablier.podspec
@@ -15,8 +15,7 @@ Pod::Spec.new do |spec|
   spec.license      = "MIT"
   spec.license      = { :type => "MIT", :file => "LICENSE" }
 
-  spec.author             = { "Akio Yasui" => "akkyie01@gmail.com" }
-  spec.social_media_url   = "https://twitter.com/akkyie"
+  spec.author       = { "Akio Yasui" => "akkyie01@gmail.com" }
 
   spec.ios.deployment_target = "8.0"
   spec.osx.deployment_target = "10.9"


### PR DESCRIPTION
Not sure about the root, but it causes CocoaPods warning on CI which leads updating podspec to fail.