### PR TITLE
Specify ENABLE_TESTING_SEARCH_PATHS option for building

### DIFF
--- a/Tablier.podspec
+++ b/Tablier.podspec
@@ -27,4 +27,7 @@ Pod::Spec.new do |spec|
   spec.requires_arc = true
 
   spec.framework  = "XCTest"
+  spec.pod_target_xcconfig = {
+     "ENABLE_TESTING_SEARCH_PATHS" => "YES"
+   }
 end


### PR DESCRIPTION
> ```
> ❌ /Users/s06092/Projects/github.com/abema/abema-ios/Pods/Tablier/Sources/Tablier/XCTest.swift:49:87: cannot find 'XCTFail' in scope
>     init(_ testCase: TestCase, fail: @escaping (String, StaticString, UInt) -> Void = XCTFail) {
>                                                                                       ^~~~~~~
> ** BUILD FAILED **
> ```